### PR TITLE
Fix ligatures option for English

### DIFF
--- a/epitran/flite.py
+++ b/epitran/flite.py
@@ -93,7 +93,7 @@ class Flite(object):
                 acc.append(chunk)
         text = ''.join(acc)
         text = self.puncnorm.norm(text) if normpunc else text
-        text = ligaturize(text) if ligatures else text
+        text = ligaturize(text) if (ligatures or self.ligatures) else text
         return text
 
     def strict_trans(self, text, normpunc=False, ligatures=False):


### PR DESCRIPTION
The issue:

Setting the option `ligutures=True` when constructing an `Epitran` object
is supposed to enable ligatures call `ligaturize` on any transliteration.
At least, this is the behavior for any `SimpleEpitran` language.
But the `Flite` class seems to behave differently.
It ignores the setting `ligatures=True` when constructing `Epitran`.

It is still possible to set ligatures=True in a particular transliteration.
E.g.
```
epi = epitran.Epitran("eng-Latn")
epi.transliterate("George", ligatures=True)
```
will properly show ligatures.
However the following does not properly show ligatures:
```
epi = epitran.Epitran("eng-Latn", ligatures=True)
epi.transliterate("George")
```