### PR TITLE
fixed CSV headers for aze-Cyrl and orm-Latn

### DIFF
--- a/epitran/data/map/aze-Cyrl.csv
+++ b/epitran/data/map/aze-Cyrl.csv
@@ -1,4 +1,4 @@
-orth,Phon
+Orth,Phon
 а,ɑ
 б,b
 ҹ,d͡ʒ

--- a/epitran/data/map/orm-Latn.csv
+++ b/epitran/data/map/orm-Latn.csv
@@ -1,4 +1,4 @@
-Orthographic,Phonetic
+Orth,Phon
 a,a
 aa,aː
 b,b


### PR DESCRIPTION
Hi, I was getting
`epitran.exceptions.DatafileError: Header is ["orth", "Phon"] instead of ["Orth", "Phon"]
.`

For `aze-Cyrl` and `orm-Latn`. I've fixed the headers in their orthographic mappings and they work now.