### PR TITLE
Update epihan.py

### DIFF
--- a/epitran/epihan.py
+++ b/epitran/epihan.py
@@ -94,7 +94,7 @@ class Epihan(object):
                 if normpunc:
                     token = self.normalize_punc(token)
                 ipa_tokens.append(token)
-            ipa_tokens = map(ligaturize, ipa_tokens)\
+        ipa_tokens = map(ligaturize, ipa_tokens)\
                 if ligatures else ipa_tokens
         return u''.join(ipa_tokens)
 


### PR DESCRIPTION
Hi @dmort27,

I've been coming across an error in Chinese transliteration whenever I use the ligatures=True feature on tokens containing more than one Chinese character:

```
Exception has occurred: AttributeError
'map' object has no attribute 'append'
```

This is due to the fact that the mapping resides within the loop over all tokens and changes the ipa_tokens list to a map object after the first token is processed, before trying to append the ipa for subsequent tokens to that map object.

You can reproduce the error by calling the transliterate function with the ligature feature flag enabled, e.g. 

```
epi.transliterate('高中', ligatures=True)
epi.transliterate('百科全', ligatures=True)
```

Unless I'm missing something (which is possible because my knowledge of Chinese is very limited), I believe this PR should do the trick to avoid getting the error.