### PR TITLE
improved Goth2Latn.csv

### DIFF
--- a/epitran/data/map/Goth2Latn.csv
+++ b/epitran/data/map/Goth2Latn.csv
@@ -3,7 +3,7 @@ Orth,Phon
 𐌱,b
 𐌲,g
 𐌳,d
-𐌴,ē
+𐌴,e
 𐌵,q
 𐌶,z
 𐌷,h
@@ -16,6 +16,7 @@ Orth,Phon
 𐌾,j
 𐌿,u
 𐍀,p
+𐍁,niuntehund
 𐍂,r
 𐍃,s
 𐍄,t
@@ -23,4 +24,5 @@ Orth,Phon
 𐍆,f
 𐍇,x
 𐍈,ƕ
-𐍉,ō
+𐍉,o
+𐍊,niunhunda


### PR DESCRIPTION
removed macrons from e and o, added two more characters to the alphabet: 𐍁,niuntehund and 𐍊,niunhunda. These symbols were used to describe numbers 90 and 900 in texts. See Braune 2004 page 21 and Wiktionary (links do work):
- https://en.wiktionary.org/wiki/%F0%90%8C%BD%F0%90%8C%B9%F0%90%8C%BF%F0%90%8C%BD%F0%90%8D%84%F0%90%8C%B4%F0%90%8C%B7%F0%90%8C%BF%F0%90%8C%BD%F0%90%8C%B3#Gothic
- https://en.wiktionary.org/wiki/%F0%90%8C%BD%F0%90%8C%B9%F0%90%8C%BF%F0%90%8C%BD_%F0%90%8C%B7%F0%90%8C%BF%F0%90%8C%BD%F0%90%8C%B3%F0%90%8C%B0#Gothic