### PR TITLE
yue: syllabic nasals should have tones

### DIFF
--- a/epitran/data/post/yue-Latn.txt
+++ b/epitran/data/post/yue-Latn.txt
@@ -4,6 +4,5 @@
 
 % Make isolated nasals syllabic
 
-m -> m̩ / # _ #
-ŋ -> ŋ̩ / # _ #
-
+m -> m̩ / # _ [˩˨˧˦˥]+ #
+ŋ -> ŋ̩ / # _ [˩˨˧˦˥]+ #


### PR DESCRIPTION
Addressing the issue at https://github.com/dmort27/epitran/commit/1f3d0e896f98a0eb8481b55d294ceb7bb4483775#commitcomment-70373919

Previously,
```ng6``` did not get marked as a syllabic consonant ŋ̩˨ because the tone was not included in the environment of the postprocessing rule