### PR TITLE
Hakka: fix bugs

### DIFF
--- a/epitran/data/map/hak-Latn.csv
+++ b/epitran/data/map/hak-Latn.csv
@@ -9,7 +9,6 @@ th,tʰ
 n,n
 l,l
 k,k
-ki,k
 kh,kʰ
 ng,ŋ
 ngi,ɲ

--- a/epitran/data/pre/hak-Latn.txt
+++ b/epitran/data/pre/hak-Latn.txt
@@ -21,6 +21,6 @@ y -> i / # _
 
 % add extra i because the i should not be lost as a vowel but is also used to condition the consonant in the map
 chi -> chii / # _
-chhi -> chii / # _
+chhi -> chhii / # _
 si -> sii / # _
 ngi -> ngii / # _


### PR DESCRIPTION
Issues
* ki should not lose vowel
   * ki becomes ki in Northern Sixian but ci in Meixian dialect but we are only using Northern Sixian for now
   * either way, the i should be preserved
   * for now, we do not need a separate entry for ki since we are going with the Northern Sixian dialect
* chhii should not lose aspiration