### PR TITLE
yue: fix postprocessing rule

### DIFF
--- a/epitran/data/post/yue-Latn.txt
+++ b/epitran/data/post/yue-Latn.txt
@@ -1,6 +1,9 @@
+% note: any word-final rules need to
+%   account for the tones already being word-final in Jyutping
+
 % Deaspirate word-finally
 
-ʰ -> 0 / _ #
+ʰ -> 0 / _ [˩˨˧˦˥]+ #
 
 % Make isolated nasals syllabic
 


### PR DESCRIPTION
Previously, the rule was not being applied because no word fit the rule. Specifically, all words in Jyutping ended with a tone, so ʰ would never be in the final position. As such, we revise the postprocessing rule to include tones in the environment