### PR TITLE
Hokkien: fixes

### DIFF
--- a/epitran/data/map/nan-Latn.csv
+++ b/epitran/data/map/nan-Latn.csv
@@ -22,6 +22,7 @@ ng,ŋ
 h,h
 a,a
 e,e
+ee,ɛ
 er,ɘ
 or,ɤ
 o,ɤ

--- a/epitran/data/map/nan-Latn.csv
+++ b/epitran/data/map/nan-Latn.csv
@@ -30,6 +30,7 @@ ong,ɔŋ
 om,ɔm
 op,ɔp
 ok,ɔk
+iok,i̯ɔk
 i,i
 ir,ɨ
 u,u

--- a/epitran/data/post/nan-Latn.txt
+++ b/epitran/data/post/nan-Latn.txt
@@ -5,9 +5,19 @@
 h -> ʔ / _ #
 h -> ʔ / _ ˥ #
 
+% neutral tone. create artificial marker that prevents the following rules from applying
+% if the word already had a tone, it is unaffected
+-- -> 輕 / # _
+(?P<sw1>輕)(?P<sw2>[^輕]+) -> 0 / _
+
 % the following rules rely on the tone already being moved to the end of the word
 % ends in h,p,t,k and does not have a tone diacritic - 4th tone
+% and does not start with --
 0 -> ˧ / [ʔptk] _ #
 
 % if no tone diacritic and does not end in a stop - 1st tone
-0 -> ˥ / ([^˩˨˧˦˥]) _ #
+% ensure it is not neutral tone either (i.e. beginning with --)
+0 -> ˥ / ([^˩˨˧˦˥輕]) _ #
+
+% remove artificial neutral tone marker
+輕 -> 0 / _ #


### PR DESCRIPTION
1. handle neutral tone

for words like --ooh, remove the -- and do not add any tone marker. 
the word may already have a tone, though, for example, --ê, in which case, we will just use the tone that already comes with the word

2. add the -iok final
This final is listed in the Ministry of Education's list of phonemes (https://blgjts.moe.edu.tw/doc/tmt_compare.pdf), but I failed to include it in the POJ version. 

This caused ```epi.transliterate('chiok')``` to output t͡ɕi̯ɤk˧ instead of t͡ɕi̯ɔk˧. In this specific example, the i is duplicated to ensure we get the right initial chi-. the duplicate i is then paired with o to form io because -io is a valid final. However, -io is pronounced i̯ɤ whereas -iok is i̯ɔk. The solution is to include -iok in the mapping table