### PR TITLE
fix: add Hokkien -iang and Hakka -ung; fix Hakka -oa

### DIFF
--- a/epitran/data/map/hak-Latn.csv
+++ b/epitran/data/map/hak-Latn.csv
@@ -24,7 +24,7 @@ i,i
 u,u
 a,a
 ia,i̯a
-oa,o̯a
+oa,u̯a
 e,e
 ie,i̯e
 oe,u̯e
@@ -67,6 +67,7 @@ iang,i̯aŋ
 oang,u̯aŋ
 ong,oŋ
 iong,i̯oŋ
+ung,uŋ
 iung,i̯uŋ
 ṳp,ɨp
 ip,ip

--- a/epitran/data/map/nan-Latn.csv
+++ b/epitran/data/map/nan-Latn.csv
@@ -39,6 +39,7 @@ ai,ai̯
 au,au̯
 ia,i̯a
 ian,i̯ɛn
+iang,i̯aŋ
 iat,i̯ɛt
 eng,i̯əŋ
 ek,i̯ək


### PR DESCRIPTION
Bug found in https://github.com/cmu-llab/wikihan/issues/1
Some engmas had not been converted to ŋ and were left as ng.

The reason is that I forgot to add Hokkien -iang and Hakka -ung to the mapping tables. After verifying with https://en.wiktionary.org/wiki/Module:nan-pron and https://en.wiktionary.org/wiki/Wiktionary:About_Chinese/Hakka, I found that I indeed missed these 2 finals. 

I also fixed fix Hakka -oa. 