### PR TITLE
Updated pronunciation of Hungarian "ng"

### DIFF
--- a/epitran/data/map/hun-Latn.csv
+++ b/epitran/data/map/hun-Latn.csv
@@ -41,6 +41,8 @@ n,n
 nn,nː
 ny,ɲ
 nny,ɲː
+ng,ŋ
+nng,ŋː
 o,o
 ó,oː
 ö,ø

--- a/epitran/data/map/hun-Latn.csv
+++ b/epitran/data/map/hun-Latn.csv
@@ -42,6 +42,7 @@ nn,nː
 ny,ɲ
 nny,ɲː
 ng,ŋ
+ngy,ɲɟ
 nng,ŋː
 o,o
 ó,oː

--- a/epitran/data/post/hun-Latn.txt
+++ b/epitran/data/post/hun-Latn.txt
@@ -1,0 +1,4 @@
+::vowel:: = ɒ|a|ɛ|e|i|o|ø|u|y
+
+% restore <ɡ> before vowels 
+ŋ -> ŋɡ / _ (::vowel::)

--- a/epitran/test/test_hungarian.py
+++ b/epitran/test/test_hungarian.py
@@ -41,3 +41,6 @@ class TestHungarianGeneral(unittest.TestCase):
 
     def test_hangtan(self):
         self._assert_trans('hangtan', 'hɒŋtɒn')
+
+    def test_gyongy(self):
+        self._assert_trans('gyöngy', 'ɟøɲɟ')

--- a/epitran/test/test_hungarian.py
+++ b/epitran/test/test_hungarian.py
@@ -21,11 +21,23 @@ class TestHungarianGeneral(unittest.TestCase):
     def test_fiaei(self):
         self._assert_trans('fiáéi', 'fiaːeːi')
 
+    def test_fiaiei(self):
+        self._assert_trans('fiaiéi', 'fiɒieːi')
+
     def test_baratnoje(self):
         self._assert_trans('barátnője', 'bɒraːtnøːjɛ')
 
     def test_magyar(self):
         self._assert_trans('magyar', 'mɒɟɒr')
 
-    def test_(self):
-        self._assert_trans('nagyszülő', 'nɒɟsyløː')
+    def test_nagyszulo(self):
+        self._assert_trans('nagyszülő', 'nɒɟsyløː')  # is actually pronounced as nat͡sːyløː
+
+    def test_hang(self):
+        self._assert_trans('hang', 'hɒŋ')
+
+    def test_henger(self):
+        self._assert_trans('henger', 'hɛŋɡɛr')
+
+    def test_hangtan(self):
+        self._assert_trans('hangtan', 'hɒŋtɒn')


### PR DESCRIPTION
and added some tests, which are passing:
```
epitran/test/test_hungarian.py::TestHungarianGeneral::test_fiaei PASSED  [ 44%]
epitran/test/test_hungarian.py::TestHungarianGeneral::test_fiaiei PASSED [ 44%]
epitran/test/test_hungarian.py::TestHungarianGeneral::test_hang PASSED   [ 45%]
epitran/test/test_hungarian.py::TestHungarianGeneral::test_hangtan PASSED [ 45%]
epitran/test/test_hungarian.py::TestHungarianGeneral::test_henger PASSED [ 45%]
epitran/test/test_hungarian.py::TestHungarianGeneral::test_magyar PASSED [ 46%]
epitran/test/test_hungarian.py::TestHungarianGeneral::test_nagyszulo PASSED [ 46%]
``` 