### PR TITLE
Update spa-Latn.csv

### DIFF
--- a/epitran/data/map/spa-Latn.csv
+++ b/epitran/data/map/spa-Latn.csv
@@ -16,7 +16,7 @@ gui,ɡi
 gü,ɡw
 h,
 hi,ʝ
-hu,w
+hu,u
 j,x
 k,k
 l,l

--- a/epitran/data/pre/spa-Latn.txt
+++ b/epitran/data/pre/spa-Latn.txt
@@ -1,6 +1,4 @@
 ::vowels:: = a|e|i|o|u
-...
-i -> [j] / _ ::vowels::
-u -> [w] / _ ::vowels::
+
 i -> [j] / ::vowels:: _ ::vowels::
 u -> [w] / ::vowels:: _ ::vowels::

--- a/epitran/data/pre/spa-Latn.txt
+++ b/epitran/data/pre/spa-Latn.txt
@@ -1,4 +1,4 @@
 ::vowels:: = a|e|i|o|u
 
-i -> [j] / ::vowels:: _ ::vowels::
-u -> [w] / ::vowels:: _ ::vowels::
+i -> j / ::vowels:: _ ::vowels::
+u -> w / ::vowels:: _ ::vowels::

--- a/epitran/data/pre/spa-Latn.txt
+++ b/epitran/data/pre/spa-Latn.txt
@@ -1,0 +1,3 @@
+::vowels:: = a|e|i|o|u
+i -> [j] / _ ::vowels::
+u -> [w] / _ ::vowels::

--- a/epitran/data/pre/spa-Latn.txt
+++ b/epitran/data/pre/spa-Latn.txt
@@ -1,3 +1,6 @@
 ::vowels:: = a|e|i|o|u
+...
 i -> [j] / _ ::vowels::
 u -> [w] / _ ::vowels::
+i -> [j] / ::vowels:: _ ::vowels::
+u -> [w] / ::vowels:: _ ::vowels::


### PR DESCRIPTION
"hu" is pronounced [w] only if a vowel comes next, therefore the "h" is silent and "u" is pronounced [u].


> Finally, the semivowels [j] and [w] can be assigned to the phonemes /i/ and /u/, as there are no minimal contrasts in Spanish between the sounds [i] and [j] or between [u] and [w]. Thus the semivowels can be seen as the forms taken by /i/ or /u/ when they occur in a diphthong with another vowel. Each semivowel can occur immediately before or immediately after the vowel with which it forms a diphthong, as is shown in Table 2 below.

**Table 2   Distribution of the semivowels [j] and [w]**

|                | Before vowel   | After vowel   |
|----------------|----------------|---------------|
| [j]   | [tjera]  tierra 'land'     | [bojna] boina 'beret'  |
| [w]   | [fweɣo]  fuego   'fire'   | [ewɾopa]  Europa  'Europe'  |




https://www.staff.ncl.ac.uk/i.e.mackenzie/conssemi.htm


