### PR TITLE
Japanese support

### DIFF
--- a/epitran/_epitran.py
+++ b/epitran/_epitran.py
@@ -3,7 +3,7 @@ import logging
 from typing import Union
 
 import panphon.featuretable
-from epitran.epihan import Epihan, EpihanTraditional
+from epitran.epihan import Epihan, EpihanTraditional, EpiJpan
 from epitran.flite import FliteLexLookup
 from epitran.puncnorm import PuncNorm
 from epitran.simple import SimpleEpitran
@@ -26,7 +26,8 @@ class Epitran(object):
     """
     special = {'eng-Latn': FliteLexLookup,
                'cmn-Hans': Epihan,
-               'cmn-Hant': EpihanTraditional}
+               'cmn-Hant': EpihanTraditional,
+               'jpn-Hira': EpiJpan,}
 
     def __init__(self, code: str, preproc: bool=True, postproc: bool=True, ligatures: bool=False,
                 cedict_file: Union[bool, None]=None, rev: bool=False, 

--- a/epitran/epihan.py
+++ b/epitran/epihan.py
@@ -125,3 +125,34 @@ class EpihanTraditional(Epihan):
         self.cedict = cedict.CEDictTrie(cedict_file, traditional=True)
         self.rules = rules.Rules([rules_file])
         self.regexp = re.compile(r'\p{Han}')
+
+class EpiJpan(object):
+    def __init__(self, ligatures=False, cedict_file=None, tones=False):
+        """Construct epitran object for Japanese
+
+        Args:
+            ligatures (bool): if True, use ligatures instead of standard IPA
+            cedict_file (str): path to src dictionary file
+        """
+        if not cedict_file:
+            print(os.path.dirname(__file__))
+            cedict_file = os.path.join(os.path.dirname(__file__), 'data', 'rules', 'ja.txt')
+        self.cedict = cedict.CEDictTrieForJapanese(cedict_file)
+        self.regexp = None
+        self.tones = tones
+        
+    def transliterate(self, text, normpunc=False, ligatures=False):
+        tokens = self.cedict.tokenize(text)
+        # print(tokens)
+        ipa_tokens = []
+        for token in tokens:
+            if token in self.cedict.character:
+                ipa = self.cedict.character[token]
+                ipas = u''.join(ipa).lower()
+                ipa_tokens.append(ipas.replace(u',', u''))
+            else:
+                if normpunc:
+                    token = self.normalize_punc(token)
+                ipa_tokens.append(token)
+                
+        return u''.join(ipa_tokens)


### PR DESCRIPTION
Adding support for Japanese.

- Since the high similarity of Chinese and Japanese, I used the same method for Japanese IPA transfer as Chinese. There is one support cedict_file to construct JPA system.
- You could get the support file through https://github.com/open-dict-data/ipa-dict/blob/master/data/ja.txt. Please put it under epitran/epitran/data/rules/.

