### PR TITLE
Add support for Afrikaans by fixing mistake

### DIFF
--- a/epitran/data/map/afr-Latn.csv
+++ b/epitran/data/map/afr-Latn.csv
@@ -1,4 +1,4 @@
-Orth, Phon
+Orth,Phon
 ä, a
 ae, ɑːə
 é, eː

--- a/epitran/data/map/afr-Latn.csv
+++ b/epitran/data/map/afr-Latn.csv
@@ -1,74 +1,74 @@
 Orth,Phon
-ä, a
-ae, ɑːə
-é, eː
-è, e
-í, i
-î, əː
-ï, i
-ŉ, ə
-ó, o
-ö, o
-q, k
-ú, œ
-x, z
-ý, əi
-au, ou
-ey, əi
-ns, ns
-oi, oj
-uy, œy
-a, a
-aa, ɑː
-aai, ɑːi
-ai, ai
-b, b
-c, k
-ch, ʃ
-d, d
-dj, d͡ʒ
-e, eː
-ê, eː
-ee, ɪə
-eeu, ɪu
-ei, ei
-eu, ɪɵ
-f, f
-g, χ
-gh, g
-h, ɦ
-i, i
-ie, iː
-j, j
-k, k
-l, l
-m, m
-n, n
-ng, ŋ
-o, o
-ô, oː
-oe, uː
-oei, ui
-oo, ʊə
-ooi, oːi
-ou, ɵu
-p, p
-r, r
-s, s
-sj, ʃ
-t, t
-tj, kj
-u, ɵ
-û, ɵː
-ui, ɵi
-uu, yː
-v, f
-w, v
-y, əi
-z, z
-îe, əːə
-ieë, iː
-ieu, iu
-ôe, ɔː
-oeë, uː
-ow, ou
+ä,a
+ae,ɑːə
+é,eː
+è,e
+í,i
+î,əː
+ï,i
+ŉ,ə
+ó,o
+ö,o
+q,k
+ú,œ
+x,z
+ý,əi
+au,ou
+ey,əi
+ns,ns
+oi,oj
+uy,œy
+a,a
+aa,ɑː
+aai,ɑːi
+ai,ai
+b,b
+c,k
+ch,ʃ
+d,d
+dj,d͡ʒ
+e,eː
+ê,eː
+ee,ɪə
+eeu,ɪu
+ei,ei
+eu,ɪɵ
+f,f
+g,χ
+gh,g
+h,ɦ
+i,i
+ie,iː
+j,j
+k,k
+l,l
+m,m
+n,n
+ng,ŋ
+o,o
+ô,oː
+oe,uː
+oei,ui
+oo,ʊə
+ooi,oːi
+ou,ɵu
+p,p
+r,r
+s,s
+sj,ʃ
+t,t
+tj,kj
+u,ɵ
+û,ɵː
+ui,ɵi
+uu,yː
+v,f
+w,v
+y,əi
+z,z
+îe,əːə
+ieë,iː
+ieu,iu
+ôe,ɔː
+oeë,uː
+ow,ou


### PR DESCRIPTION
This commit fixes mistake in file renaming (bb71008) and removing space after comma in csv.
However, one should be careful, as I manually checked some of the test cases in [Wikipedia](https://en.wikipedia.org/wiki/Afrikaans_phonology), but it doesn't seem to potentally match well, so one might want to re-implement it.

| Orth | Wikipedia | Epitran |
|--------|--------|--------|
| dief | dif |  diːɱfɛː |
| suutjies | ˈsykis | syːŋkjiːsɛː |
| boek | buk | buːŋkɛː |
| seun | sɪøn | sɪɵnɛː |
| hy | ɦəɪ̯ | ɦəiɛː | 