### PR TITLE
Fixes typo in Japanese post rules

### DIFF
--- a/epitran/data/post/jpn-Hira.txt
+++ b/epitran/data/post/jpn-Hira.txt
@@ -18,7 +18,7 @@ oo -> oː / _
 
 %Some special notations for long vowels
 ei -> eː / _
-ou -> oː / _
+oɯ -> oː / _
 
 % allophones of "[ら-ろ]" & "[りゃ-りょ]"
 ɾ -> ɖ / # _

--- a/epitran/data/post/jpn-Kana.txt
+++ b/epitran/data/post/jpn-Kana.txt
@@ -18,7 +18,7 @@ oo -> oː / _
 
 %Some special notations for long vowels
 ei -> eː / _
-ou -> oː / _
+oɯ -> oː / _
 
 % allophones of "[ラ-ロ]" & "[リャ-リョ]"
 ɾ -> ɖ / # _


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Language addition, bug fix, feature, docs update, ...)

Bug fix: Changed `u` to `ɯ` in one rule in both `data/post/jpn-Hira.txt` and `data/post/jpn-Kana.txt`.

<!-- Use below for everything else -->
* **What is the current behavior?** (You can also link to an open issue here)

See #219: words like とうきょう/トウキョウ are incorrectly transcribed as /toukʲou/ rather than /toːkʲoː/.


* **What is the new behavior (if this is a feature change)?**

See above.


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

This will have a substantial effect on output transcriptions.

