### PR TITLE
Modernize Python 2 compatibility code for Python 3.10+

### DIFF
--- a/epitran/cedict.py
+++ b/epitran/cedict.py
@@ -43,9 +43,9 @@ class CEDictTrie(object):
         pairs = []
         for hz, df in self.hanzi.items():
             py, en = df
-            py = str(''.join(filter(lambda x: x in ASCII_CHARS, ' '.join(py))))
+            py = ''.join(filter(lambda x: x in ASCII_CHARS, ' '.join(py)))
             pairs.append((hz, (py.encode('utf-8'),)))
-        trie = marisa_trie.RecordTrie(str('@s'), pairs)
+        trie = marisa_trie.RecordTrie('@s', pairs)
         return trie
 
     def has_key(self, key: str) -> bool:
@@ -131,7 +131,7 @@ class CEDictTrieForJapanese(object):
         pairs = []
         for ch, pron in self.character.items():
             pairs.append((ch, (pron.encode('utf-8'),)))
-        trie = marisa_trie.RecordTrie(str('@s'), pairs)
+        trie = marisa_trie.RecordTrie('@s', pairs)
         return trie
 
     def has_key(self, key: str) -> bool:

--- a/epitran/flite.py
+++ b/epitran/flite.py
@@ -50,7 +50,6 @@ class Flite(object):
         return arpa_map
 
     def normalize(self, text: str) -> str:
-        text = str(text)
         text = unicodedata.normalize('NFD', text)
         text = ''.join(filter(lambda x: x in string.printable, text))
         return text
@@ -136,7 +135,6 @@ class Flite(object):
                 return [to_vector(seg) for seg in self.ft.ipa_segs(phon)]
 
         tuples = []
-        word = str(word)
         # word = self.strip_diacritics.process(word)
         word = unicodedata.normalize('NFKD', word)
         word = unicodedata.normalize('NFC', word)

--- a/epitran/ppprocessor.py
+++ b/epitran/ppprocessor.py
@@ -4,7 +4,7 @@ import os.path
 
 from typing import Union
 
-import pkg_resources
+from importlib import resources
 
 from epitran.rules import Rules
 
@@ -32,12 +32,12 @@ class PrePostProcessor(object):
         code += '_rev' if rev else ''
         fn = os.path.join('data', fix, code + '.txt')
         try:
-            abs_fn = pkg_resources.resource_filename(__name__, fn)
-        except KeyError:
-            return Rules([])
-        if os.path.isfile(abs_fn):
-            return Rules([abs_fn])
-        else:
+            resource_path = resources.files(__package__).joinpath(fn)
+            if resource_path.is_file():
+                return Rules([resource_path])
+            else:
+                return Rules([])
+        except (KeyError, FileNotFoundError):
             return Rules([])
 
     def process(self, word: str) -> str:

--- a/epitran/puncnorm.py
+++ b/epitran/puncnorm.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 
-import pkg_resources
 import csv
+from importlib import resources
 from typing import Dict, Iterator
 
 
@@ -12,8 +12,7 @@ class PuncNorm(object):
 
     def _load_punc_norm_map(self) -> Dict[str, str]:
         """Load the map table for normalizing 'down' punctuation."""
-        path = pkg_resources.resource_filename(__name__, 'data/puncnorm.csv')
-        with open(path, 'r', encoding='utf-8') as f:
+        with resources.files(__package__).joinpath('data/puncnorm.csv').open('r', encoding='utf-8') as f:
             reader = csv.reader(f, delimiter=',', quotechar='"')
             next(reader)
             return {punc: norm for (punc, norm) in reader}

--- a/epitran/reromanize.py
+++ b/epitran/reromanize.py
@@ -4,7 +4,7 @@ import sys
 from unicodedata import normalize
 from typing import Dict, List, Optional
 
-import pkg_resources
+from importlib import resources
 
 import epitran
 import csv
@@ -29,10 +29,10 @@ class ReRomanizer(object):
 
     def _load_reromanizer(self, table: str, decompose: bool) -> Dict[str, str]:
         path = os.path.join('data', 'reromanize', table + '.csv')
-        path = pkg_resources.resource_filename(__name__, path)
-        if os.path.isfile(path):
+        path = resources.files(__package__).joinpath(path)
+        if path.is_file():
             mapping = {}
-            with open(path, 'r', encoding='utf-8') as f:
+            with path.open('r', encoding='utf-8') as f:
                 reader = csv.reader(f)
                 next(reader)
                 for ipa, rom in reader:

--- a/epitran/space.py
+++ b/epitran/space.py
@@ -3,7 +3,7 @@
 import os
 from typing import Dict, List, Iterator
 
-import pkg_resources
+from importlib import resources
 import csv
 from epitran import Epitran
 
@@ -33,15 +33,15 @@ class Space(object):
         punc_fns = ['punc-{}.csv'.format(sc) for sc in scripts]
         for punc_fn in punc_fns:
             punc_fn = os.path.join('data', 'space', punc_fn)
-            punc_fn = pkg_resources.resource_filename(__name__, punc_fn)
-            with open(punc_fn, 'r', encoding='utf-8') as f:
+            punc_fn = resources.files(__package__).joinpath(punc_fn)
+            with punc_fn.open('r', encoding='utf-8') as f:
                 reader = csv.reader(f)
                 for (mark,) in reader:
                     segs.add(mark)
         for name in space_names:
             fn = os.path.join('data', 'space', name + '.csv')
-            fn = pkg_resources.resource_filename(__name__, fn)
-            with open(fn, 'r', encoding='utf-8') as f:
+            fn = resources.files(__package__).joinpath(fn)
+            with fn.open('r', encoding='utf-8') as f:
                 reader = csv.reader(f)
                 for _, to_ in reader:
                     for seg in self.epi.ft.ipa_segs(to_):

--- a/epitran/stripdiacritics.py
+++ b/epitran/stripdiacritics.py
@@ -3,7 +3,7 @@
 import os.path
 from typing import List
 
-import pkg_resources
+from importlib import resources
 
 import csv
 
@@ -21,14 +21,14 @@ class StripDiacritics(object):
         diacritics = []
         fn = os.path.join('data', 'strip', code + '.csv')
         try:
-            abs_fn = pkg_resources.resource_filename(__name__, fn)
-        except KeyError:
-            return []
-        if os.path.isfile(abs_fn):
-            with open(abs_fn, 'r', encoding='utf-8') as f:
-                reader = csv.reader(f)
-                for [diacritic] in reader:
-                    diacritics.append(diacritic)
+            resource_path = resources.files(__package__).joinpath(fn)
+            if resource_path.is_file():
+                with resource_path.open('r', encoding='utf-8') as f:
+                    reader = csv.reader(f)
+                    for [diacritic] in reader:
+                        diacritics.append(diacritic)
+        except (KeyError, FileNotFoundError):
+            pass
         return diacritics
 
     def process(self, word: str) -> str:

--- a/epitran/tir2pp.py
+++ b/epitran/tir2pp.py
@@ -2,15 +2,15 @@
 
 import os.path
 
-import pkg_resources
+from importlib import resources
 from . import rules
 
 
 class Tir2PP(object):
     def __init__(self) -> None:
         fn = os.path.join('data', 'post', 'tir-Ethi-pp.txt')
-        fn = pkg_resources.resource_filename(__name__, fn)
-        self.rules = rules.Rules([fn])
+        resource_path = resources.files(__package__).joinpath(fn)
+        self.rules = rules.Rules([resource_path])
 
     def apply(self, word: str) -> str:
         word = word.replace('ɨ', '')

--- a/epitran/xsampa.py
+++ b/epitran/xsampa.py
@@ -4,7 +4,7 @@ import os.path
 import unicodedata
 from typing import List
 
-import pkg_resources
+from importlib import resources
 
 import marisa_trie
 import panphon
@@ -22,9 +22,9 @@ class XSampa(object):
 
     def _read_ipa2xs(self) -> marisa_trie.BytesTrie:
         path = os.path.join('data', self.ipa2xs_fn)
-        path = pkg_resources.resource_filename(__name__, path)
+        path = resources.files(__package__).joinpath(path)
         pairs = []
-        with open(path, 'r', encoding='utf-8') as f:
+        with path.open('r', encoding='utf-8') as f:
             reader = csv.reader(f)
             next(reader)
             for ipa, xs, _ in reader:


### PR DESCRIPTION
* **What kind of change does this PR introduce?** Code modernization and refactoring

* **What is the current behavior?** 
The codebase contains Python 2 compatibility code including:
- Usage of deprecated `pkg_resources` package causing deprecation warnings
- Unnecessary `str()` calls that were needed for Python 2 compatibility
- Use of `io.open()` instead of built-in `open()` function
- Redundant string casting in various places

* **What is the new behavior (if this is a feature change)?**
This PR modernizes the codebase for Python 3.10+ by:
- Replacing `pkg_resources` with modern `importlib.resources` throughout the codebase
- Enhancing the `Rules` class to handle both string paths and `importlib.resources` Path objects
- Removing unnecessary `str()` calls that were needed for Python 2 compatibility
- Replacing `io.open()` with built-in `open()` function
- Removing redundant string casting in CSV readers and marisa_trie calls

* **Does this PR introduce a breaking change?** 
No breaking changes. The modernization maintains full backward compatibility while eliminating deprecation warnings and improving code quality.

## Changes Made

### Files Modified:
- `epitran/ppprocessor.py` - Replaced pkg_resources with importlib.resources
- `epitran/stripdiacritics.py` - Replaced pkg_resources with importlib.resources  
- `epitran/space.py` - Replaced pkg_resources with importlib.resources
- `epitran/simple.py` - Replaced pkg_resources, removed unnecessary str() calls
- `epitran/xsampa.py` - Replaced pkg_resources with importlib.resources
- `epitran/puncnorm.py` - Replaced pkg_resources with importlib.resources
- `epitran/reromanize.py` - Replaced pkg_resources with importlib.resources
- `epitran/tir2pp.py` - Replaced pkg_resources with importlib.resources
- `epitran/rules.py` - Enhanced to handle importlib.resources Path objects, replaced io.open()
- `epitran/cedict.py` - Removed redundant str() calls in marisa_trie usage
- `epitran/flite.py` - Removed redundant str() calls in text processing

### Key Improvements:
- ✅ Eliminates all `pkg_resources` deprecation warnings
- ✅ Modernizes resource loading using `importlib.resources`
- ✅ Removes Python 2 compatibility overhead
- ✅ Maintains full backward compatibility
- ✅ All existing tests pass successfully

This modernization prepares the codebase for future Python versions and eliminates technical debt from Python 2 compatibility code.