### PR TITLE
New tests and phonetic rules for Russian

### DIFF
--- a/epitran/data/map/rus-Cyrl.csv
+++ b/epitran/data/map/rus-Cyrl.csv
@@ -14,10 +14,12 @@ Orth,Phon
 л,l
 м,m
 н,n
+нн,n
 о,o
 п,p
 р,r
 с,s
+сс,s
 т,t
 у,u
 ф,f

--- a/epitran/data/pre/rus-Cyrl.txt
+++ b/epitran/data/pre/rus-Cyrl.txt
@@ -1,3 +1,39 @@
+::voiceless:: = п|т|к|ф|с|ш
+% NB <v> doesn't trigger voicing
+::voiced:: = б|д|г|з|ж
+::hushers:: = [шжц]
+
+%% Lexical and regular sound changes
+% g -> v in <-ogo> <-ego>
+г -> в / [ое] _ о#
+% lexical exception
+сегодня -> сиводня / _
+
+% g -> x before <k>
+г -> х / _ [кч]
+% lexical exception
+бог -> бох / _
+
+% final de-voicing
+б -> п / _ ь?(#|::voiceless::)
+д -> т / _ ь?(#|::voiceless::)
+г -> к / _ ь?(#|::voiceless::)
+в -> ф / _ ь?(#|::voiceless::)
+з -> с / _ ь?(#|::voiceless::)
+ж -> ш / _ ь?(#|::voiceless::)
+
+% Voicing in clusters
+п -> б / _ ь?(::voiced::)
+т -> д / _ ь?(::voiced::)
+к -> г / _ ь?(::voiced::)
+ф -> в / _ ь?(::voiced::)
+с -> з / _ ь?(::voiced::)
+ш -> ж / _ ь?(::voiced::)
+
+% i -> y after sibilants
+и -> ы / (::hushers::) _
+
+%% j-normalization
 ьйэ -> ъе / _
 ьйа -> ъя / _
 
@@ -20,4 +56,4 @@
 0 -> й / # _ (е|ё|ю|я)
 
 % Palatalization
-0 -> ь / (б|в|д|з|к|л|м|п|р|с|т|ф|х) _ (j|е|ё|и|ю|я)
+0 -> ь / (б|в|д|з|л|м|н|п|р|с|т|ф) _ (j|е|ё|и|ю|я)

--- a/epitran/test/test_russian.py
+++ b/epitran/test/test_russian.py
@@ -20,4 +20,50 @@ class TestRussian(unittest.TestCase):
 
     def test_vzglat(self):
         tr = self.epi.transliterate('взгляд')
-        self.assertEqual(tr, 'vzɡlʲad')
+        self.assertEqual(tr, 'vzɡlʲat')
+
+    def test_exceptions(self):
+        """Lexical exceptions to general phonetic rules."""
+        tr = self.epi.transliterate('сегодня')
+        self.assertEqual(tr, 'sʲivodnʲa')
+        tr = self.epi.transliterate('бог')
+        self.assertEqual(tr, 'box')
+
+    def test_g_softening(self):
+        """The letter г is pronounced as /v/ or /x/ in certain regular contexts."""
+        pairs = [
+            ('легко', 'lʲexko'),
+            ("мягкий", 'mʲaxkij'),
+            ('легчать', 'lʲext͡ɕʲatʲ'),
+            ("чего", 't͡ɕʲevo'),
+            ("кого", 'kovo')
+        ]
+        for orth, phon in pairs:
+            tr = self.epi.transliterate(orth)
+            self.assertEqual(tr, phon)
+
+    def test_voicing_assimilation(self):
+        pairs = [
+            ('все', 'fsʲe'),
+            ('встретить', 'fstrʲetʲitʲ'),
+            ("рассказ", 'raskas'),
+            ("сделать", 'zdʲelatʲ'),
+            ("просьба", 'prozʲba'),
+            ("водка", 'votka'),
+        ]
+        for orth, phon in pairs:
+            tr = self.epi.transliterate(orth)
+            self.assertEqual(tr, phon)
+
+    def test_hushers(self):
+        pairs = [
+            ('жить', 'ʒɨtʲ'),
+            ('шить', 'ʂɨtʲ'),
+            ("цифра", 't͡sɨfra'),
+        ]
+        for orth, phon in pairs:
+            tr = self.epi.transliterate(orth)
+            self.assertEqual(tr, phon)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
* **What kind of change does this PR introduce?** Fix issues with accuracy in Russian transcription

* **What is the current behavior?** Russian transcription follows orthography too closely, resulting in incorrect IPA for words like [легко](https://en.wiktionary.org/wiki/%D0%BB%D0%B5%D0%B3%D0%BA%D0%BE#Russian), [кого](https://en.wiktionary.org/wiki/%D0%BA%D0%BE%D0%B3%D0%BE#Russian), [встретить](https://en.wiktionary.org/wiki/%D0%B2%D1%81%D1%82%D1%80%D0%B5%D1%82%D0%B8%D1%82%D1%8C#Russian), etc.

* **What is the new behavior (if this is a feature change)?** Rules for voicing assimilation, final consonant devoicing, and regular changes in pronunciation of <г> and <и> are accounted for, resulting in a more accurate pronunication. Vowel reduction has not been added as stress is out-of-scope.

* **Sources of information for the rules** Own knowledge as an L2 speaker; textbooks *Beginner's Russian* and *V Puti* by Kudyma, Miller, and Kagan; Wikipedia (esp. [Russian Phonology](https://en.wikipedia.org/wiki/Russian_phonology) article)
* 
* **Sources of information for the test samples** Own knowledge plus Wiktionary for gold-standard IPA

* **Does this PR introduce a breaking change?** No structural changes in the API, only rule updates.
